### PR TITLE
Bump flink version and speedup downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Fixed
 
 ## [X.Y.Z](https://github.com/idealista/flink_role/tree/X.Y.Z)
-### [Full Changelog](https://github.com/idealista/flink_role/compare/1.0.0...X.Y.Z)
+### [Full Changelog](https://github.com/idealista/flink_role/compare/1.1.0...X.Y.Z)
 ### Changed
- *[#<issue_number>](https://github.com/idealista/flink_role/issues/<issue_number>) \<Change description\>* @\<author\>
+*[#<issue_number>](https://github.com/idealista/flink_role/issues/<issue_number>) \<Change description\>* @\<author\>
+
+
+## [1.1.0](https://github.com/idealista/flink_role/tree/1.1.0)
+### [Full Changelog](https://github.com/idealista/flink_role/compare/1.0.0...1.1.0)
+### Changed
+- *Bump flink version to 1.15.0* @eskabetxe
+- *Speedup downloads if last version of minor is used* @eskabetxe
 
 ## [1.0.0](https://github.com/idealista/flink_role/tree/1.0.0)
 - *First version* @eskabetxe

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## General
-flink_version: 1.14.2
+flink_version: 1.15.0
 flink_scala_version: 2.12
 
 # Owner
@@ -37,11 +37,17 @@ flink_slaves_template_path: templates/slaves.j2
 flink_configuration:
     jobmanager.rpc.address: localhost
     jobmanager.rpc.port: 6123
+    jobmanager.bind-host: localhost
     jobmanager.memory.process.size: 1600m
+    taskmanager.bind-host: localhost
+    taskmanager.host: localhost
     taskmanager.memory.process.size: 1728m
     taskmanager.numberOfTaskSlots: 1
     parallelism.default: 1
     jobmanager.execution.failover-strategy: region
+    rest.address: localhost
+    rest.bind-address: localhost
+
 
 flink_manager_type: [jobmanager, taskmanager, history]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,10 +20,11 @@ flink_jobs_path: "{{ flink_data_path }}/jobs"
 flink_extra_path: []
 
 # Download paths
-flink_mirror: "https://archive.apache.org/dist/flink"
+flink_mirror: "https://downloads.apache.org/flink"
+flink_mirror_archive: "https://archive.apache.org/dist/flink"
 flink_package_name: "flink-{{ flink_version }}-bin-scala_{{ flink_scala_version }}"
 flink_package: "{{ flink_package_name }}.tgz"
-flink_bin_url: "{{ flink_mirror }}/flink-{{ flink_version }}/{{ flink_package }}"
+flink_bin_url: "/flink-{{ flink_version }}/{{ flink_package }}"
 
 # Templates path
 flink_jobmanger_service_template_path: templates/flink-jobmanager.service.j2

--- a/molecule/multiplenodes/group_vars/all/flink.yml
+++ b/molecule/multiplenodes/group_vars/all/flink.yml
@@ -1,6 +1,6 @@
 ---
 
-flink_version: 1.14.2
+flink_version: 1.15.0
 flink_user: flink
 flink_group: flink
 flink_service_state: started

--- a/molecule/multiplenodes/tests/test_flink.yml
+++ b/molecule/multiplenodes/tests/test_flink.yml
@@ -11,7 +11,7 @@ file:
     contains:
       - org.apache.flink.metrics.prometheus.PrometheusReporter
       - 9249
-  /opt/flink/plugins/metrics-prometheus/flink-metrics-prometheus-1.14.2.jar:
+  /opt/flink/plugins/metrics-prometheus/flink-metrics-prometheus-1.15.0.jar:
     exists: true
 
 http:
@@ -23,7 +23,7 @@ command:
     exit-status: 0
     exec: /opt/flink/bin/flink -v
     stdout:
-      - "Version: 1.14.2"
+      - "Version: 1.15.0"
     stderr: []
     timeout: 10000 # in milliseconds
     skip: false

--- a/molecule/singlenode/group_vars/all/flink.yml
+++ b/molecule/singlenode/group_vars/all/flink.yml
@@ -1,6 +1,6 @@
 ---
 
-flink_version: 1.14.2
+flink_version: 1.15.0
 flink_user: flink
 flink_group: flink
 flink_install_path: "/opt/flink"

--- a/molecule/singlenode/tests/test_flink.yml
+++ b/molecule/singlenode/tests/test_flink.yml
@@ -52,7 +52,7 @@ command:
     exit-status: 0
     exec: "/opt/flink/bin/flink -v"
     stdout:
-      - "Version: 1.14.2"
+      - "Version: 1.15.0"
     stderr: []
     timeout: 10000 # in milliseconds
     skip: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,26 +22,41 @@
   args:
     chdir: "{{ flink_install_path }}/bin"
 
-- name: FLINK | Delete installation older
-  file:
-    path: "{{ flink_install_path }}"
-    state: absent
+- name: FLINK | Install
+  block:
+    - name: FLINK | Delete installation older
+      file:
+        path: "{{ flink_install_path }}"
+        state: absent
+
+    - name: FLINK | Create install path
+      file:
+        path: "{{ flink_install_path }}"
+        state: directory
+        owner: "{{ flink_user }}"
+        group: "{{ flink_group }}"
+        mode: 0755
+
+    - name: FLINK | Untar flink
+      unarchive:
+        extra_opts: ['--strip-components=1']
+        src: "{{ flink_mirror + flink_bin_url }}"
+        remote_src: true
+        dest: "{{ flink_install_path }}"
+        owner: "{{ flink_user }}"
+        group: "{{ flink_group }}"
+      register: flink_download
+      ignore_errors: true
+
+    - name: FLINK | Untar flink by archive
+      unarchive:
+        extra_opts: ['--strip-components=1']
+        src: "{{ flink_mirror_archive + flink_bin_url }}"
+        remote_src: true
+        dest: "{{ flink_install_path }}"
+        owner: "{{ flink_user }}"
+        group: "{{ flink_group }}"
+      when: 'flink_download is failed'
+
   when: 'flink_force_reinstall or flink_check is failed or flink_check.stdout|length == 0'
 
-- name: FLINK | Create install path
-  file:
-    path: "{{ flink_install_path }}"
-    state: directory
-    owner: "{{ flink_user }}"
-    group: "{{ flink_group }}"
-    mode: 0755
-
-- name: FLINK | Untar flink
-  unarchive:
-    extra_opts: ['--strip-components=1']
-    src: "{{ flink_bin_url }}"
-    remote_src: true
-    dest: "{{ flink_install_path }}"
-    owner: "{{ flink_user }}"
-    group: "{{ flink_group }}"
-  when: 'flink_force_reinstall or flink_check is failed or flink_check.stdout|length == 0'

--- a/templates/flink-conf.yaml.j2
+++ b/templates/flink-conf.yaml.j2
@@ -1,3 +1,3 @@
-{% for key, value in flink_configuration.items() %}
+{% for key, value in (flink_configuration | dictsort) %}
 {{ key }}: {{ value }}
 {% endfor %}


### PR DESCRIPTION
### Description of the Change

- Bump flink version to 1.15.0
- Sort config in flink-conf.yaml 
- Try download mirror and if fail archive mirror

### Benefits

- Last version of flink, and speed up download if minor last version is used

### Possible Drawbacks

none

### Applicable Issues

none
