### PR TITLE
BIG-2812: add configuration to limit restarting services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,6 +68,9 @@ flink_workers: ['localhost']
 flink_service_enabled: true
 # current state: started, stopped
 flink_service_state: started
+flink_service_start_limit_burst: 5
+flink_service_start_limit_interval_sec: 400
+flink_service_restart_sec: 60
 
 ## Miscellaneous
 flink_force_reinstall: false

--- a/templates/flink-jobmanager.service.j2
+++ b/templates/flink-jobmanager.service.j2
@@ -1,13 +1,13 @@
 [Unit]
 Description=Apache Flink
 After=network.target
-StartLimitIntervalSec=400
-StartLimitBurst=5
+StartLimitIntervalSec={{ flink_service_start_limit_interval_sec }}
+StartLimitBurst={{ flink_service_start_limit_burst }}
 
 [Service]
 Type=forking
 Restart=on-failure
-RestartSec=60
+RestartSec={{ flink_service_restart_sec }}
 {% if flink_env_variables | length > 0 %}
 {% for var in flink_env_variables | select('!=', '')  %}
 Environment="{{ var }}"

--- a/templates/flink-jobmanager.service.j2
+++ b/templates/flink-jobmanager.service.j2
@@ -1,10 +1,13 @@
 [Unit]
 Description=Apache Flink
 After=network.target
+StartLimitIntervalSec=400
+StartLimitBurst=5
 
 [Service]
 Type=forking
 Restart=on-failure
+RestartSec=60
 {% if flink_env_variables | length > 0 %}
 {% for var in flink_env_variables | select('!=', '')  %}
 Environment="{{ var }}"

--- a/templates/flink-taskmanager.service.j2
+++ b/templates/flink-taskmanager.service.j2
@@ -1,13 +1,13 @@
 [Unit]
 Description=Apache Flink
 After=network.target
-StartLimitIntervalSec=400
-StartLimitBurst=5
+StartLimitIntervalSec={{ flink_service_start_limit_interval_sec }}
+StartLimitBurst={{ flink_service_start_limit_burst }}
 
 [Service]
 Type=forking
 Restart=on-failure
-RestartSec=60
+RestartSec={{ flink_service_restart_sec }}
 {% if flink_env_variables | length > 0 %}
 {% for var in flink_env_variables | select('!=', '')  %}
 Environment="{{ var }}"

--- a/templates/flink-taskmanager.service.j2
+++ b/templates/flink-taskmanager.service.j2
@@ -1,10 +1,13 @@
 [Unit]
 Description=Apache Flink
 After=network.target
+StartLimitIntervalSec=400
+StartLimitBurst=5
 
 [Service]
 Type=forking
 Restart=on-failure
+RestartSec=60
 {% if flink_env_variables | length > 0 %}
 {% for var in flink_env_variables | select('!=', '')  %}
 Environment="{{ var }}"


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

Add configuration from systemd.service to control the number of times that taskmanager and jobmanager services are restarted in case of failure.

Now, they are unlimited


- https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=

- https://manpages.debian.org/testing/systemd/systemd.unit.5.en.html

### Benefits

The services are restarting without limit. 
For example, when the zookeeper service is unreachable, the flink cluster begins to restart and log files are created in every attempt.

### Possible Drawbacks

if the limit of attempts is exceeded in StartLimitIntervalSec period , the services will have to be restarted manually 

### Applicable Issues

<!-- Enter any applicable Issues here -->
